### PR TITLE
Fixed metric latency unit and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ cachet:
     - CREATE_INCIDENT
     - UPDATE_STATUS
   public_incidents: true
+  latency_unit: ms
 frequency: 30
-latency_unit: ms
 ```
 
 - **endpoint**, the configuration about the URL that will be monitored.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ frequency: 30
         - **CREATE_INCIDENT**, we will create an incident when the expectation fails.
         - **UPDATE_STATUS**, updates the component status
     - **public_incidents**, boolean to decide if created incidents should be visible to everyone or only to logged in users. Important only if `CREATE_INCIDENT` or `UPDATE_STATUS` are set.
+    - **latency_unit**, the latency unit used when reporting the metrics. It will automatically convert to the specified unit. It's not mandatory and it will default to **seconds**. Available units: `ms`, `s`, `m`, `h`.
 - **frequency**, how often we'll send a request to the given URL. The unit is in seconds.
-- **latency_unit**, the latency unit used when reporting the metrics. It will automatically convert to the specified unit. It's not mandatory and it will default to **seconds**. Available units: `ms`, `s`, `m`, `h`.
 
 ## Setting up
 

--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -258,7 +258,7 @@ class Configuration(object):
 
             if metrics_request.ok:
                 # Successful metrics upload
-                self.logger.info('Metric uploaded: %.6f seconds' % (value,))
+                self.logger.info('Metric uploaded: %.6f %s' % (value, self.latency_unit))
             else:
                 self.logger.warning('Metric upload failed with status [%d]' %
                                     (metrics_request.status_code,))

--- a/config.yml
+++ b/config.yml
@@ -19,5 +19,5 @@ cachet:
     - CREATE_INCIDENT
     - UPDATE_STATUS
   public_incidents: true
+  latency_unit: ms
 frequency: 30
-latency_unit: ms


### PR DESCRIPTION
Moved `latency_unit` in the `cachet` yaml dictionary (where the code tries to read it from) and updated logger to show actual latency unit.