### PR TITLE
Return status as integer

### DIFF
--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -60,7 +60,7 @@ def get_current_status(endpoint_url, component_id, headers):
 
     if get_status_request.ok:
         # The component exists.
-        return get_status_request.json()['data']['status']
+        return int(get_status_request.json()['data']['status'])
     else:
         raise ComponentNonexistentError(component_id)
 


### PR DESCRIPTION
During the first start the if statement on line 237 does not get evaluated correctly and will not "return"
Therefore by any restart the first evaluation triggers a update even if the original status is same.