### PR TITLE
Dont update if same

### DIFF
--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -241,6 +241,11 @@ class Configuration(object):
         if not self.trigger_update:
             return
 
+        self.api_component_status = get_current_status(self.api_url, self.component_id, self.headers)
+
+        if self.status == self.api_component_status:
+            return
+
         params = {'id': self.component_id, 'status': self.status}
         component_request = requests.put('%s/components/%d' % (self.api_url, self.component_id), params=params,
                                          headers=self.headers)

--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -60,7 +60,7 @@ def get_current_status(endpoint_url, component_id, headers):
 
     if get_status_request.ok:
         # The component exists.
-        return get_status_request.json()['data']['status']
+        return int(get_status_request.json()['data']['status'])
     else:
         raise ComponentNonexistentError(component_id)
 


### PR DESCRIPTION
By a case where allowed_fails > 0 and one failure is received the url monitor pushes a unnecessary update as the component state was not changed, resulting in a notification of "component is operational", but in fact the component was still operation before the update.

This creates another api call (get) towards the cachet, but it is a better trade-off to prevent unnecessary notifications for end-users.