### PR TITLE
Avoid using schedule

### DIFF
--- a/cachet_url_monitor/scheduler.py
+++ b/cachet_url_monitor/scheduler.py
@@ -5,7 +5,6 @@ import threading
 import time
 import os
 
-import schedule
 from yaml import load, SafeLoader
 
 from cachet_url_monitor.client import CachetClient
@@ -35,11 +34,6 @@ class Agent(object):
 
         for decorator in self.decorators:
             decorator.execute(self.configuration)
-
-    def start(self):
-        """Sets up the schedule based on the configuration file."""
-        schedule.every(self.configuration.endpoint['frequency']).seconds.do(self.execute)
-
 
 class Decorator(object):
     """Defines the actions a user can configure to be executed when there's an incident."""
@@ -77,10 +71,9 @@ class Scheduler(object):
         self.stop = False
 
     def start(self):
-        self.agent.start()
         self.logger.info('Starting monitor agent...')
         while not self.stop:
-            schedule.run_pending()
+            self.agent.execute()
             time.sleep(self.configuration.endpoint['frequency'])
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PyYAML==5.3
 requests==2.22.0
-schedule==0.6.0
 Click==7.0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,7 +4,6 @@ import unittest
 
 import mock
 
-sys.modules['schedule'] = mock.Mock()
 from cachet_url_monitor.scheduler import Agent, Scheduler
 
 
@@ -23,14 +22,6 @@ class AgentTest(unittest.TestCase):
 
         evaluate.assert_called_once()
         push_status.assert_not_called()
-
-    def test_start(self):
-        every = sys.modules['schedule'].every
-        self.configuration.endpoint = {'frequency': 5}
-
-        self.agent.start()
-
-        every.assert_called_with(5)
 
 
 class SchedulerTest(unittest.TestCase):
@@ -83,5 +74,3 @@ class SchedulerTest(unittest.TestCase):
         # Leaving it as a placeholder.
         self.scheduler.stop = True
         self.scheduler.start()
-
-        self.agent.start.assert_called()


### PR DESCRIPTION
Execute task directly as there is already code taking care of the
delays.

Fixes #90

Maybe I missed something, but I see no reason of using additional scheduler, when the delays are already handled inside the code.