### PR TITLE
Avoid pushing metrics twice

### DIFF
--- a/cachet_url_monitor/scheduler.py
+++ b/cachet_url_monitor/scheduler.py
@@ -30,7 +30,6 @@ class Agent(object):
         cachet server.
         """
         self.configuration.evaluate()
-        self.configuration.push_metrics()
         self.configuration.if_trigger_update()
 
         for decorator in self.decorators:


### PR DESCRIPTION
The metrics were pushed unconditionally in the execute method and
conditionally in decorators. I think only decorators should submit it.