### PR TITLE
Remove unused token from Configuration object

### DIFF
--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -25,10 +25,8 @@ class Configuration(object):
     endpoint_index: int
     endpoint: str
     client: CachetClient
-    token: str
     current_fails: int
     trigger_update: bool
-    headers: Dict[str, str]
 
     endpoint_method: str
     endpoint_url: str
@@ -45,12 +43,11 @@ class Configuration(object):
     previous_status: ComponentStatus
     message: str
 
-    def __init__(self, config, endpoint_index: int, client: CachetClient, token: str):
+    def __init__(self, config, endpoint_index: int, client: CachetClient):
         self.endpoint_index = endpoint_index
         self.data = config
         self.endpoint = self.data['endpoints'][endpoint_index]
         self.client = client
-        self.token = token
 
         self.current_fails = 0
         self.trigger_update = True
@@ -68,8 +65,6 @@ class Configuration(object):
         self.validate()
 
         # We store the main information from the configuration file, so we don't keep reading from the data dictionary.
-
-        self.headers = {'X-Cachet-Token': self.token}
 
         self.endpoint_method = self.endpoint['method']
         self.endpoint_url = normalize_url(self.endpoint['url'])
@@ -174,8 +169,6 @@ class Configuration(object):
 
     def __repr__(self):
         temporary_data = copy.deepcopy(self.data)
-        # Removing the token so we don't leak it in the logs.
-        del temporary_data['cachet']['token']
         temporary_data['endpoints'] = temporary_data['endpoints'][self.endpoint_index]
 
         return dump(temporary_data, default_flow_style=False)

--- a/cachet_url_monitor/scheduler.py
+++ b/cachet_url_monitor/scheduler.py
@@ -136,6 +136,6 @@ if __name__ == "__main__":
     for endpoint_index in range(len(config_data['endpoints'])):
         token = os.environ.get('CACHET_TOKEN') or config_data['cachet']['token']
         api_url = os.environ.get('CACHET_API_URL') or config_data['cachet']['api_url']
-        configuration = Configuration(config_data, endpoint_index, CachetClient(api_url, token), token)
+        configuration = Configuration(config_data, endpoint_index, CachetClient(api_url, token))
         NewThread(Scheduler(configuration,
                             build_agent(configuration, logging.getLogger('cachet_url_monitor.scheduler')))).start()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -56,25 +56,24 @@ def mock_logger():
 
 @pytest.fixture()
 def configuration(config_file, mock_client, mock_logger):
-    yield Configuration(config_file, 0, mock_client, 'token2')
+    yield Configuration(config_file, 0, mock_client)
 
 
 @pytest.fixture()
 def multiple_urls_configuration(multiple_urls_config_file, mock_client, mock_logger):
-    yield [Configuration(multiple_urls_config_file, index, mock_client, 'token2') for index in
+    yield [Configuration(multiple_urls_config_file, index, mock_client) for index in
            range(len(multiple_urls_config_file['endpoints']))]
 
 
 def test_init(configuration):
     assert len(configuration.data) == 2, 'Number of root elements in config.yml is incorrect'
     assert len(configuration.expectations) == 3, 'Number of expectations read from file is incorrect'
-    assert configuration.headers == {'X-Cachet-Token': 'token2'}, 'Header was not set correctly'
     assert configuration.endpoint_header == {'SOME-HEADER': 'SOME-VALUE'}, 'Header is incorrect'
 
 
 def test_init_unknown_status(config_file, mock_client):
     mock_client.get_component_status.return_value = cachet_url_monitor.status.ComponentStatus.UNKNOWN
-    configuration = Configuration(config_file, 0, mock_client, 'token2')
+    configuration = Configuration(config_file, 0, mock_client)
 
     assert configuration.previous_status == cachet_url_monitor.status.ComponentStatus.UNKNOWN
 
@@ -173,7 +172,6 @@ def test_init_multiple_urls(multiple_urls_configuration):
         config = multiple_urls_configuration[index]
         assert len(config.data) == 2, 'Number of root elements in config.yml is incorrect'
         assert len(config.expectations) == 1, 'Number of expectations read from file is incorrect'
-        assert config.headers == {'X-Cachet-Token': 'token2'}, 'Header was not set correctly'
 
         assert expected_method[index] == config.endpoint_method
         assert expected_url[index] == config.endpoint_url
@@ -181,4 +179,4 @@ def test_init_multiple_urls(multiple_urls_configuration):
 
 def test_init_invalid_configuration(invalid_config_file, mock_client):
     with pytest.raises(cachet_url_monitor.configuration.ConfigurationValidationError):
-        Configuration(invalid_config_file, 0, mock_client, 'token2')
+        Configuration(invalid_config_file, 0, mock_client)


### PR DESCRIPTION
It is not used anywhere, Cachet is called through Client.