### PR TITLE
add option for SSL verify=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,29 @@ endpoints:
     public_incidents: true
     latency_unit: ms
     frequency: 5
+  - name: Insecure-site
+    url: https://www.Insecure-site-internal.com
+    method: GET
+    header:
+      SOME-HEADER: SOME-VALUE
+      insecure: 
+    timeout: 1 # seconds
+    expectation:
+      - type: HTTP_STATUS
+        status_range: 200-205
+        incident: MAJOR
+      - type: LATENCY
+        threshold: 1
+      - type: REGEX
+        regex: ".*<body>.*"
+        threshold: 10
+    allowed_fails: 0
+    component_id: 2
+    action:
+      - CREATE_INCIDENT
+    public_incidents: true
+    latency_unit: ms
+    frequency: 5    
 cachet:
   api_url: http://status.cachethq.io/api/v1
   token:
@@ -91,6 +114,7 @@ messages:
     - **url**, the URL that is going to be monitored. *mandatory*
     - **method**, the HTTP method that will be used by the monitor. *mandatory*
     - **header**, client header passed to the request. Remove if you do not want to pass a header.
+      - **insecure**, for URLs which have self-singed/invalid SSL certs OR you wish to disable SSL check, use this header key. Do not need to provide any value, If header is present, SSL check is false. Default is true, if key not present. 
     - **timeout**, how long we'll wait to consider the request failed. The unit of it is seconds. *mandatory*
     - **expectation**, the list of expectations set for the URL. *mandatory*
         - **HTTP_STATUS**, we will verify if the response status code falls into the expected range. Please keep in

--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -158,7 +158,12 @@ class Configuration(object):
         """
         try:
             if self.endpoint_header is not None:
-                self.request = requests.request(
+                if "insecure" in self.endpoint_header:
+                    self.request = requests.request(
+                    self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout, headers=self.endpoint_header, verify=False
+                )
+                else:
+                    self.request = requests.request(
                     self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout, headers=self.endpoint_header
                 )
             else:


### PR DESCRIPTION
Often internal tools/site use self-singed or incorrect certs. 
To disable SSL check for https urls, adding this header. 
This can be implemented it several better ways, this is my quick way. 