### PR TITLE
Support extract metric value from request body by defining endpoint['measure']['regex']

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ messages:
     - **latency_unit**, the latency unit used when reporting the metrics. It will automatically convert to the
      specified unit. It's not mandatory and it will default to **seconds**. Available units: `ms`, `s`, `m`, `h`.
     - **frequency**, how often we'll send a request to the given URL. The unit is in seconds.
+    - **measure**, which thing we use to measure the metric value
+        - **regex**, the regex pattern to extract metric value from body, the first matched group will be used for metric value. Ex: `value=([0-9.]+)`
 - **cachet**, this is the settings for our cachet server.
     - **api_url**, the cachet API endpoint. *mandatory*
     - **token**, the API token. It can either be a string (backwards compatible with old configuration) or a list of

--- a/cachet_url_monitor/client.py
+++ b/cachet_url_monitor/client.py
@@ -5,7 +5,7 @@ from typing import Optional
 import click
 import requests
 from yaml import dump
-from cachet_url_monitor import latency_unit, status, exceptions
+from cachet_url_monitor import status, exceptions
 
 
 def normalize_url(url: str) -> str:
@@ -89,10 +89,9 @@ class CachetClient(object):
         params = {"id": component_id, "status": component_status.value}
         return requests.put(f"{self.url}/components/{component_id}", params=params, headers=self.headers)
 
-    def push_metrics(self, metric_id: int, latency_time_unit: str, elapsed_time_in_seconds: int, timestamp: int):
-        """Pushes the total amount of seconds the request took to get a response from the URL.
+    def push_metrics(self, metric_id: int, value: float, timestamp: int):
+        """Pushes the metric value to the cachet server.
         """
-        value = latency_unit.convert_to_unit(latency_time_unit, elapsed_time_in_seconds)
         params = {"id": metric_id, "value": value, "timestamp": timestamp}
         return requests.post(f"{self.url}/metrics/{metric_id}/points", params=params, headers=self.headers)
 


### PR DESCRIPTION
This will be useful for people who one to public internal metric or from internal monitoring tool to the public Cachet page