### PR TITLE
avoid random endpoints header to activate insecure flag

### DIFF
--- a/cachet_url_monitor/configuration.py
+++ b/cachet_url_monitor/configuration.py
@@ -158,7 +158,10 @@ class Configuration(object):
         """
         try:
             if self.endpoint_header is None:
-                self.request = requests.request(self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout)
+                self.request = requests.request(
+                    self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout,
+                    verify=not self.endpoint['insecure'] if 'insecure' in self.endpoint else True
+                )
             else:
                 self.request = requests.request(
                     self.endpoint_method, self.endpoint_url, timeout=self.endpoint_timeout, headers=self.endpoint_header,

--- a/tests/configs/config_insecure_without_header.yml
+++ b/tests/configs/config_insecure_without_header.yml
@@ -1,0 +1,25 @@
+endpoints:
+  - name: foo
+    url: http://localhost:8080/swagger
+    method: GET
+    insecure: true
+    timeout: 0.01
+    expectation:
+      - type: HTTP_STATUS
+        status_range: 200-300
+        incident: MAJOR
+      - type: LATENCY
+        threshold: 1
+      - type: REGEX
+        regex: '.*(<body).*'
+    allowed_fails: 0
+    component_id: 1
+    action:
+      - CREATE_INCIDENT
+      - UPDATE_STATUS
+    public_incidents: true
+    latency_unit: ms
+    frequency: 30
+cachet:
+  api_url: https://demo.cachethq.io/api/v1
+  token: my_token


### PR DESCRIPTION
if header is not present in a endpoint configuration, the insecure flag is not taken into account